### PR TITLE
Featured issues

### DIFF
--- a/app.py
+++ b/app.py
@@ -43,6 +43,27 @@ def embed():
     # Render index and pass in all of the organization names
     return render_template('embed.html', organization_names=names)
 
+@app.route('/geeks/civicissues/widget/featured')
+def featured_issues():
+    ''' Pull from a list of featured issues
+    '''
+    issues_url = 'http://codeforamerica.org/api/issues/featured?per_page=3'
+
+    # Get the actual issues from the API
+    issues_response = get(issues_url)
+    issues_json = issues_response.json()
+    issues = issues_json['objects']
+
+    if len(issues) < 3:
+        more = 3 - len(issues)
+        issues_url = 'http://codeforamerica.org/api/issues/labels/help wanted?per_page=' + str(more)
+        issues_response = get(issues_url)
+        issues_json = issues_response.json()
+        more_issues = issues_json['objects']
+        issues = issues + more_issues
+
+    return render_template('widget.html', issues=issues, labels='help wanted')
+
 
 @app.route('/geeks/civicissues/widget')
 def widget():
@@ -83,28 +104,6 @@ def widget():
     issues = issues_json['objects']
 
     return render_template('widget.html', issues=issues, labels=labels)
-
-@app.route('/geeks/civicissues/widget?labels=help%20wanted&number=3')
-def featured_issues():
-    ''' Pull from a list of featured issues
-    '''
-
-    issues_url = 'http://codeforamerica.org/api/issues/featured?per_page=3'
-
-    # Get the actual issues from the API
-    issues_response = get(issues_url)
-    issues_json = issues_response.json()
-    issues = issues_json['objects']
-
-    if len(issues) < 3:
-        more = 3 - len(issues)
-        issues_url = 'http://localhost:5000/api/issues/labels/help wanted?per_page=' + more
-        issues_response = get(issues_url)
-        issues_json = issues_response.json()
-        more_issues = issues_json['objects']
-        issues = issues + more_issues
-
-    return render_template('widget.html', issues=issues, labels='help wanted')
 
 if __name__ == "__main__":
     app.run(debug=True)

--- a/app.py
+++ b/app.py
@@ -84,5 +84,27 @@ def widget():
 
     return render_template('widget.html', issues=issues, labels=labels)
 
+@app.route('/geeks/civicissues/widget?labels=help%20wanted&number=3')
+def featured_issues():
+    ''' Pull from a list of featured issues
+    '''
+
+    issues_url = 'http://codeforamerica.org/api/issues/featured?per_page=3'
+
+    # Get the actual issues from the API
+    issues_response = get(issues_url)
+    issues_json = issues_response.json()
+    issues = issues_json['objects']
+
+    if len(issues) < 3:
+        more = 3 - len(issues)
+        issues_url = 'http://localhost:5000/api/issues/labels/help wanted?per_page=' + more
+        issues_response = get(issues_url)
+        issues_json = issues_response.json()
+        more_issues = issues_json['objects']
+        issues = issues + more_issues
+
+    return render_template('widget.html', issues=issues, labels='help wanted')
+
 if __name__ == "__main__":
     app.run(debug=True)


### PR DESCRIPTION
I started a featured Civic Issues feature.

We'd replace the embedded widget on the CfA homepage with the new embed of 
`http://codeforamerica.org/geeks/civicissues/widget/featured`

It pulls three featured issues. It grabs regular issues if there aren't three left. It doesn't have tests yet and I might not have time to write them before Summit.
### Tasks
- [ ] Write simple tests for this and CfAPI
- [ ] Merge this PR
- [ ] Merge the [featured-issues branch on the CfAPI](https://github.com/codeforamerica/cfapi/tree/featured-issues) too 
- [ ] Upgrade the db of the cfapi `heroku run python app.py db upgrade`
- [ ] Get this CfAPI ids of the GitHub Issues to feature. [Here is a gist](https://gist.github.com/ondrae/e2b04f4a00156f93a1ef) of the ones I like.
- [ ] Mark them as featured. They'll then show up in the /featured widget
- [ ] Replace CfA.org embed with this new one.

@migurski @pui I could use some help with this, if we think Jen or Tim will be promoting it.
