### PR TITLE
Add tracking conditional for widget

### DIFF
--- a/app.py
+++ b/app.py
@@ -114,4 +114,4 @@ def engine_light():
     return jsonify(state)
 
 if __name__ == "__main__":
-    app.run(port=7654,debug=True)
+    app.run(debug=True)

--- a/app.py
+++ b/app.py
@@ -54,6 +54,7 @@ def widget():
     org_name = request.args.get('organization_name')
     org_type = request.args.get('org_type')
     number = request.args.get('number')
+    tracking_status = request.args.get('tracking')
 
     # Build the url
     issues_url = 'https://www.codeforamerica.org/api/'
@@ -82,7 +83,7 @@ def widget():
     issues_json = issues_response.json()
     issues = issues_json['objects']
 
-    return render_template('widget.html', issues=issues, labels=labels)
+    return render_template('widget.html', issues=issues, labels=labels, tracking_status=tracking_status)
 
 @app.route("/geeks/civicissues/.well-known/status")
 def engine_light():
@@ -113,4 +114,4 @@ def engine_light():
     return jsonify(state)
 
 if __name__ == "__main__":
-    app.run(debug=True)
+    app.run(port=7654,debug=True)

--- a/templates/widget.html
+++ b/templates/widget.html
@@ -75,7 +75,8 @@
         elems[i].setAttribute('src', elems[i].getAttribute('url'));
       }
     });
-
+   
+   {% if (tracking_status != 'false') %}
     (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
     (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
     m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
@@ -83,7 +84,7 @@
 
     ga('create', 'UA-20825280-1', 'auto');
     ga('send', 'pageview');
-
+  {% endif %}
   </script>
 
 </html>


### PR DESCRIPTION
This adds a new URL param called 'tracking'. This will allow us to solve the problem where Civic Issue Finder iframes loaded in a codeforamerica.org page confuse Google Analytics, and mess with our page views.